### PR TITLE
Bug/fix existing failures

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,4 @@
-{}
+{
+  "screenshotOnRunFailure": false,
+  "video": false
+}

--- a/cypress/integration/rancid-tomatillos-test.js
+++ b/cypress/integration/rancid-tomatillos-test.js
@@ -16,7 +16,7 @@ describe('Rancid Tomatillos', () => {
     cy.get('a[id=337401]')
       .click();
     cy.contains('Mulan')
-    cy.contains('53%')
+    cy.contains('51%')
   });
 
   it('each movie displayed should have a unique alt tag', () => {
@@ -31,13 +31,13 @@ describe('Rancid Tomatillos', () => {
       .should('include', 'Rogue')
   });
 
-  it.only('should reveal a selected movie\'s details when clicked', () => {
+  it('should reveal a selected movie\'s details when clicked', () => {
     cy.get('a[id=337401]').click()
     cy.get('.image-container')
       .find('img')
       .should('have.attr', 'src')
       .should('include','https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg')
-    cy.contains('53%')
+    cy.contains('51%')
     cy.contains('When the Emperor')
     cy.contains('Action')
     cy.contains('2020-09-04')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rancid-tomatillos",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.9",


### PR DESCRIPTION
## What does this PR do?

- Fix failing cypress test
- Update cypress configs so screenshots and videos are not automatically saved

## How should it be tested in the UI?

- Run 'npm test' and ensure all tests pass
- Screenshots and videos should not be available in the Cypress folder after the tests complete
